### PR TITLE
Use Mac's ln unconditionally

### DIFF
--- a/presto-docs.sh
+++ b/presto-docs.sh
@@ -53,7 +53,7 @@ perl -pi -e 's@<loc>/index.html@<loc>/@g' $VERSION/sitemap.xml
 perl -pi -e 's@<loc>@<loc>https://prestosql.io/docs/current@g' $VERSION/sitemap.xml
 
 echo "/current/* /$VERSION/:splat 200" > _redirects
-ln -sfh $VERSION current
+/bin/ln -sfh $VERSION current
 
 git add $VERSION _redirects current
 


### PR DESCRIPTION
Mac-provided `ln` and GNU `ln` has different set of switches.
This fixes the script in case brew-installed GNU `ln` is on PATH.