### PR TITLE
Fix for docs announcement bar 

### DIFF
--- a/trino-docs.sh
+++ b/trino-docs.sh
@@ -53,16 +53,17 @@ s@<header class=\"md-header\" data-md-component=\"header\">
     Presto SQL is now Trino
     <a href=\"https://trino.io/blog/2020/12/27/announcing-trino.html\" target=\"_blank\">Read why &raquo;</a>
   </div>
-  <header class=\"md-header\" data-md-component=\"header\">
+</div>
+<header class=\"md-header\" data-md-component=\"header\">
 @;
-s@</header>@</header></div>@
+s@</header>@</header>@
 "
 
 cat <<EOT >> $VERSION/_static/trino.css
 
 .md-sidebar { padding-block-start: 75px; }
 .md-content { padding-block-start: 50px; }
-header.md-header { top: auto; }
+header.md-header { top: 53px; }
 #announcement {
   z-index: 2;
   position: fixed;
@@ -86,6 +87,14 @@ header.md-header { top: auto; }
 #announcement-content a {
   text-decoration: underline;
   margin-left: 32px;
+}
+.md-typeset span[id]:target:before {
+    margin-top:-92px;
+    padding-top:92px;
+}
+.md-typeset dl[id]:target:before {
+    margin-top:-134px;
+    padding-top:134px;
 }
 EOT
 


### PR DESCRIPTION
Currently the header bar is contained within the announcement bar `div`, which breaks the search overlay on mobile. 

This PR changes the location of the closing `div` to separate the header bar from the announcement bar.

This PR also includes some additional CSS for the structure change to position the header bar under the announcement bar, as well as give the `:ref:` `:target` anchors additional space to clear the extra height of the announcement bar. 

I *believe* the CSS changes for the `:targets` will take precedence over the current styles, so that we can avoid using `important` tags. This is also nice, so that when we decide to remove the announcement bar, our [current CSS ](https://github.com/trinodb/trino/pull/7982) should still work. 

⚠️ I tested this by updating the HTML with Chrome inspector. 

⚠️ I'm not 100% on how to test build with this, but I think this should fix it.

Screenshots of current HTML structure vs fixed, notice `header` location:

| current | proposed |
| ---- | ---- |
| ![Screen Shot 2021-05-20 at 2 37 44 PM](https://user-images.githubusercontent.com/1330423/119031528-2fdb1380-b979-11eb-80a1-ac47c395be48.png) | ![Screen Shot 2021-05-20 at 2 37 37 PM](https://user-images.githubusercontent.com/1330423/119031544-336e9a80-b979-11eb-8016-484191acfb4b.png) |